### PR TITLE
Feat: Persist Instance Data to Parquet

### DIFF
--- a/insight_agent/instance_manager.py
+++ b/insight_agent/instance_manager.py
@@ -41,7 +41,16 @@ def onboard_instance(kind_name, instance_file):
     actual = list(df.columns)
 
     if set(expected) == set(actual):
-        return True, "Instance is valid."
+        # Persist dataset to domain/catalog/datasets/<kind_name>/latest.parquet
+        datasets_dir = os.path.join('domain', 'catalog', 'datasets', kind_name)
+        os.makedirs(datasets_dir, exist_ok=True)
+        out_path = os.path.join(datasets_dir, 'latest.parquet')
+        try:
+            # Use parquet with zstd compression
+            df.to_parquet(out_path, compression='zstd', index=False)
+        except Exception as exc:
+            return False, f"Error saving instance file: {exc}"
+        return True, f"Success! Instance for '{kind_name}' is valid and has been saved."
     else:
         missing = [c for c in expected if c not in actual]
         extra = [c for c in actual if c not in expected]

--- a/tests/insight_agent/test_instance_manager.py
+++ b/tests/insight_agent/test_instance_manager.py
@@ -27,6 +27,16 @@ def test_onboard_instance_success(tmp_path):
         success, message = onboard_instance('mock_kind', inst_f)
 
     assert success is True
+    # Check that latest.parquet was created
+    latest_path = os.path.join('domain','catalog','datasets','mock_kind','latest.parquet')
+    assert os.path.exists(latest_path)
+    # cleanup dataset
+    try:
+        os.remove(latest_path)
+        os.removedirs(os.path.dirname(latest_path))
+    except Exception:
+        pass
+
     # cleanup
     try:
         os.remove(os.path.join(kind_dir, 'mapping_effective.json'))


### PR DESCRIPTION
This PR enhances the instance onboarding flow. After validation, the uploaded data is now saved as latest.parquet with ZSTD compression, overwriting any previous instance. Tests have been updated to verify file creation.