### PR TITLE
Feat: Update Kind Creation UI with Selectbox and Description

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -1,3 +1,5 @@
 import streamlit as st
 
+st.set_page_config(page_title='Tysight', layout='wide', initial_sidebar_state='expanded')
+
 st.title('Home')

--- a/app/pages/1_Kinds.py
+++ b/app/pages/1_Kinds.py
@@ -8,7 +8,9 @@ st.markdown('Upload the required mapping workbook and a sample data file to crea
 mapping = st.file_uploader('Required Mapping Workbook', type=['xlsx', 'xls', 'csv'])
 sample = st.file_uploader('Sample Data', type=['xlsx', 'xls', 'csv'])
 
-kind_name = st.text_input('Kind Name')
+kind_options = ["NIQ POS", "Circana POS", "NIQ Panel", "Media", "Walmart POS", "Walmart Store", "Walmart Item", "Walmart MOD"]
+kind_name = st.selectbox('Kind Name', options=kind_options)
+kind_description = st.text_area('Kind Description')
 
 if st.button('Create Kind'):
     if mapping is None:
@@ -16,9 +18,9 @@ if st.button('Create Kind'):
     elif sample is None:
         st.error('Please upload the Sample Data file before creating a Kind.')
     elif not kind_name or kind_name.strip() == '':
-        st.error('Please enter a valid Kind Name.')
+        st.error('Please select a valid Kind Name.')
     else:
-        success, message = create_kind(mapping, kind_name.strip(), sample)
+        success, message = create_kind(mapping, kind_name.strip(), sample, kind_description)
         if success:
             st.success(message)
         else:

--- a/insight_agent/kind_manager.py
+++ b/insight_agent/kind_manager.py
@@ -1,4 +1,4 @@
-def create_kind(uploaded_file, kind_name, sample_file=None):
+def create_kind(uploaded_file, kind_name, sample_file=None, kind_description=''):
     """Validate a mapping workbook uploaded via Streamlit and persist it.
 
     Args:
@@ -39,6 +39,11 @@ def create_kind(uploaded_file, kind_name, sample_file=None):
         os.makedirs(base_dir, exist_ok=True)
         out_path = os.path.join(base_dir, 'required_mapping.csv')
         df.to_csv(out_path, index=False)
+        # Save description if provided
+        if kind_description is not None and kind_description != '':
+            desc_path = os.path.join(base_dir, 'description.md')
+            with open(desc_path, 'w') as dfh:
+                dfh.write(kind_description)
     except Exception as exc:
         return False, f"Error saving mapping file: {exc}"
 

--- a/tests/insight_agent/test_kind_manager.py
+++ b/tests/insight_agent/test_kind_manager.py
@@ -22,7 +22,7 @@ def test_create_kind_success(tmp_path):
         with open(sample_path, 'w', newline='') as sf:
             sf.write('num_col,str_col,date_col\n1,2,2020-01-01\n3,hello,2020-02-02')
         with open(sample_path, 'rb') as sample_f:
-            success, message = create_kind(mapping_f, 'test_kind', sample_f)
+            success, message = create_kind(mapping_f, 'test_kind', sample_f, kind_description='A test description')
 
     assert success is True
 
@@ -53,6 +53,16 @@ def test_create_kind_success(tmp_path):
     assert any(r.get('original_name')=='num_col' and r.get('format_hint')=='numeric' for r in records)
     assert any(r.get('original_name')=='str_col' and r.get('format_hint')=='string' for r in records)
     assert any(r.get('original_name')=='date_col' and r.get('format_hint')=='datetime' for r in records)
+
+    # Check description.md was created and contains the kind description
+    desc_path = os.path.join('domain','catalog','kinds','test_kind','v1','description.md')
+    assert os.path.exists(desc_path)
+    with open(desc_path,'r') as dfh:
+        assert 'A test description' in dfh.read()
+
+    # Cleanup description
+    if os.path.exists(desc_path):
+        os.remove(desc_path)
 
     # Cleanup
     if os.path.exists(out_path):


### PR DESCRIPTION
This PR replaces the free-text Kind Name input with a selectbox of standard kinds and adds a Kind Description field. The backend create_kind() now accepts the description and saves it to description.md. Tests have been updated accordingly.