### PR TITLE
chore: ignore generated domain/catalog datasets and kinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ __pycache__/
 .env
 insight_agent.egg-info/
 *.log
+
+# Ignore user-generated Kind and Instance data
+domain/catalog/datasets/
+domain/catalog/kinds/


### PR DESCRIPTION
Ignore user-generated Kind and Instance data under domain/catalog to avoid committing large or sensitive data.