### PR TITLE
Feat: AI summary for query results with token-checking

### DIFF
--- a/app/pages/3_Ask_and_Analyze.py
+++ b/app/pages/3_Ask_and_Analyze.py
@@ -68,6 +68,16 @@ if st.button('Ask'):
     from insight_agent.query_executor import execute_query
     try:
         df_result = execute_query(selected_kind, sql)
+        # Get AI summary for the result
+        from insight_agent.llm_client import get_summary_from_df
+        try:
+            summary = get_summary_from_df(df_result, prompt)
+            if summary:
+                st.markdown('**Summary:**')
+                st.markdown(summary)
+        except Exception:
+            # If summarization fails, continue to show data
+            pass
         st.markdown('**Query Results:**')
         st.dataframe(df_result)
     except Exception as e:

--- a/tests/insight_agent/test_llm_summary.py
+++ b/tests/insight_agent/test_llm_summary.py
@@ -1,0 +1,20 @@
+import pytest
+import pandas as pd
+from unittest.mock import patch
+from insight_agent.llm_client import get_summary_from_df
+
+
+def test_get_summary_from_df_mock(monkeypatch):
+    df = pd.DataFrame({'a':[1,2], 'b':['x','y']})
+
+    class MockResp:
+        def __init__(self, text):
+            self.choices = [type('C', (), {'message': type('M', (), {'content': text})})]
+
+    def fake_completion(*args, **kwargs):
+        return MockResp('This is a one-sentence summary.')
+
+    monkeypatch.setattr('litellm.completion', fake_completion)
+
+    res = get_summary_from_df(df, 'What is the top-level insight?')
+    assert 'one-sentence summary' in res or 'This is a one-sentence summary.' in res


### PR DESCRIPTION
Add get_summary_from_df which checks model context window and returns a one-sentence summary or a friendly error when too large. Integrate into UI and tests.