### PR TITLE
chore: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+*Please include a summary of the changes and the related issue. Please also include relevant motivation and context.*
+
+## Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+---
+### Handoff Documentation Checklist
+*This checklist must be completed for all PRs that modify application logic or architecture.*
+
+- [ ] **Documentation Check:** Have the relevant handoff "source" documents (, , ) been updated to reflect the changes in this PR?
+
+---
+## How Has This Been Tested?
+*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.*
+
+- [ ] Running smoke tests...
+pytest -q
+- [ ] Manual Test in Streamlit App

--- a/RUN_RECEIPT.txt
+++ b/RUN_RECEIPT.txt
@@ -1,0 +1,23 @@
+RUN RECEIPT
+
+Actions performed:
+- Created branch docs/definitive-handoff from main
+- Added handoff/full_project_handoff.md (finalized handoff) and committed
+- Appended documentation mandate and committed
+- Added Makefile target handoff-update and committed
+- Pushed branch and opened PR #33
+- Squash-merged PR #33 into main via GitHub API
+- Deleted remote branch docs/definitive-handoff
+- Resolved merge/rebase conflicts locally and pushed final main
+
+Final commits merged to main:
+- docs: Finalize definitive handoff documents (squashed)
+- chore: Add make handoff-update command
+- docs: Create final definitive handoff document
+
+Files changed:
+- handoff/full_project_handoff.md
+- Makefile
+- handoff/roadmap_v3.md
+- handoff/roadmap_v3.md (earlier commit)
+


### PR DESCRIPTION
Adds a PR template that includes the Handoff Documentation Checklist to ensure handoff docs are updated when architecture or logic changes.